### PR TITLE
TypedValues equality operators

### DIFF
--- a/src/Json/BitzArt.Json.TypedValues/Models/TypedValue.cs
+++ b/src/Json/BitzArt.Json.TypedValues/Models/TypedValue.cs
@@ -62,7 +62,7 @@ public abstract class TypedValue
     /// <param name="right">Right operand.</param>
     /// <returns><see langword="true"/> if instances are equal; otherwise, <see langword="false"/>.</returns>"
     public static bool operator ==(TypedValue left, TypedValue right)
-        => left.Equals(right);
+        => ReferenceEquals(left, right) || (left is not null && left.Equals(right));
 
     /// <summary>
     /// Compares two <see cref="TypedValue"/> instances for inequality.
@@ -71,7 +71,7 @@ public abstract class TypedValue
     /// <param name="right">Right operand.</param>
     /// <returns><see langword="true"/> if instances are not equal; otherwise, <see langword="false"/>.</returns>"
     public static bool operator !=(TypedValue left, TypedValue right)
-        => !left.Equals(right);
+        => !(left == right);
 
     /// <summary>
     /// Compares two <see cref="TypedValue"/> instances for equality.
@@ -80,7 +80,7 @@ public abstract class TypedValue
     /// <param name="right">Right operand.</param>
     /// <returns><see langword="true"/> if instances are equal; otherwise, <see langword="false"/>.</returns>"
     public static bool operator ==(TypedValue left, object right)
-        => left.Equals(right);
+        => ReferenceEquals(left, right) || (left is not null && left.Equals(right));
 
     /// <summary>
     /// Compares two <see cref="TypedValue"/> instances for inequality.
@@ -89,7 +89,7 @@ public abstract class TypedValue
     /// <param name="right">Right operand.</param>
     /// <returns><see langword="true"/> if instances are not equal; otherwise, <see langword="false"/>.</returns>"
     public static bool operator !=(TypedValue left, object right)
-        => !left.Equals(right);
+        => !(left == right);
 
     /// <summary>
     /// Compares two <see cref="TypedValue"/> instances for equality.
@@ -98,7 +98,7 @@ public abstract class TypedValue
     /// <param name="right">Right operand.</param>
     /// <returns><see langword="true"/> if instances are equal; otherwise, <see langword="false"/>.</returns>"
     public static bool operator ==(object left, TypedValue right)
-        => left.Equals(right);
+        => ReferenceEquals(left, right) || (right is not null && right.Equals(left));
 
     /// <summary>
     /// Compares two <see cref="TypedValue"/> instances for inequality.
@@ -107,7 +107,7 @@ public abstract class TypedValue
     /// <param name="right">Right operand.</param>
     /// <returns><see langword="true"/> if instances are not equal; otherwise, <see langword="false"/>.</returns>"
     public static bool operator !=(object left, TypedValue right)
-        => !left.Equals(right);
+        => !(left == right);
 
     /// <inheritdoc/>
     public override bool Equals(object? obj)

--- a/src/Json/BitzArt.Json.TypedValues/Models/TypedValue.cs
+++ b/src/Json/BitzArt.Json.TypedValues/Models/TypedValue.cs
@@ -62,7 +62,7 @@ public abstract class TypedValue
     /// <param name="right">Right operand.</param>
     /// <returns><see langword="true"/> if instances are equal; otherwise, <see langword="false"/>.</returns>"
     public static bool operator ==(TypedValue left, TypedValue right)
-        => ReferenceEquals(left, right) || (left is not null && left.Equals(right));
+        => ReferenceEquals(left, right) || Equals(left, right);
 
     /// <summary>
     /// Compares two <see cref="TypedValue"/> instances for inequality.
@@ -80,7 +80,7 @@ public abstract class TypedValue
     /// <param name="right">Right operand.</param>
     /// <returns><see langword="true"/> if instances are equal; otherwise, <see langword="false"/>.</returns>"
     public static bool operator ==(TypedValue left, object right)
-        => ReferenceEquals(left, right) || (left is not null && left.Equals(right));
+        => ReferenceEquals(left, right) || Equals(left, right);
 
     /// <summary>
     /// Compares two <see cref="TypedValue"/> instances for inequality.
@@ -98,7 +98,7 @@ public abstract class TypedValue
     /// <param name="right">Right operand.</param>
     /// <returns><see langword="true"/> if instances are equal; otherwise, <see langword="false"/>.</returns>"
     public static bool operator ==(object left, TypedValue right)
-        => ReferenceEquals(left, right) || (right is not null && right.Equals(left));
+        => ReferenceEquals(left, right) || Equals(left, right);
 
     /// <summary>
     /// Compares two <see cref="TypedValue"/> instances for inequality.
@@ -108,6 +108,26 @@ public abstract class TypedValue
     /// <returns><see langword="true"/> if instances are not equal; otherwise, <see langword="false"/>.</returns>"
     public static bool operator !=(object left, TypedValue right)
         => !(left == right);
+
+    private static bool Equals(object? left, object? right)
+    {
+        if (left is null && right is null)
+        {
+            return true;
+        }
+
+        if (left is TypedValue typedLeft)
+        {
+            return typedLeft.Equals(right);
+        }
+
+        if (right is TypedValue typedRight)
+        {
+            return typedRight.Equals(left);
+        }
+
+        return left == right;
+    }
 
     /// <inheritdoc/>
     public override bool Equals(object? obj)

--- a/src/Json/BitzArt.Json.TypedValues/Models/TypedValue.cs
+++ b/src/Json/BitzArt.Json.TypedValues/Models/TypedValue.cs
@@ -61,7 +61,7 @@ public abstract class TypedValue
     /// <param name="left">Left operand.</param>
     /// <param name="right">Right operand.</param>
     /// <returns><see langword="true"/> if instances are equal; otherwise, <see langword="false"/>.</returns>"
-    public static bool operator ==(TypedValue left, TypedValue right)
+    public static bool operator ==(TypedValue? left, TypedValue? right)
         => ReferenceEquals(left, right) || Equals(left, right);
 
     /// <summary>
@@ -70,7 +70,7 @@ public abstract class TypedValue
     /// <param name="left">Left operand.</param>
     /// <param name="right">Right operand.</param>
     /// <returns><see langword="true"/> if instances are not equal; otherwise, <see langword="false"/>.</returns>"
-    public static bool operator !=(TypedValue left, TypedValue right)
+    public static bool operator !=(TypedValue? left, TypedValue? right)
         => !(left == right);
 
     /// <summary>
@@ -79,7 +79,7 @@ public abstract class TypedValue
     /// <param name="left">Left operand.</param>
     /// <param name="right">Right operand.</param>
     /// <returns><see langword="true"/> if instances are equal; otherwise, <see langword="false"/>.</returns>"
-    public static bool operator ==(TypedValue left, object right)
+    public static bool operator ==(TypedValue? left, object? right)
         => ReferenceEquals(left, right) || Equals(left, right);
 
     /// <summary>
@@ -88,7 +88,7 @@ public abstract class TypedValue
     /// <param name="left">Left operand.</param>
     /// <param name="right">Right operand.</param>
     /// <returns><see langword="true"/> if instances are not equal; otherwise, <see langword="false"/>.</returns>"
-    public static bool operator !=(TypedValue left, object right)
+    public static bool operator !=(TypedValue? left, object? right)
         => !(left == right);
 
     /// <summary>
@@ -97,7 +97,7 @@ public abstract class TypedValue
     /// <param name="left">Left operand.</param>
     /// <param name="right">Right operand.</param>
     /// <returns><see langword="true"/> if instances are equal; otherwise, <see langword="false"/>.</returns>"
-    public static bool operator ==(object left, TypedValue right)
+    public static bool operator ==(object? left, TypedValue? right)
         => ReferenceEquals(left, right) || Equals(left, right);
 
     /// <summary>
@@ -106,10 +106,10 @@ public abstract class TypedValue
     /// <param name="left">Left operand.</param>
     /// <param name="right">Right operand.</param>
     /// <returns><see langword="true"/> if instances are not equal; otherwise, <see langword="false"/>.</returns>"
-    public static bool operator !=(object left, TypedValue right)
+    public static bool operator !=(object? left, TypedValue? right)
         => !(left == right);
 
-    private static bool Equals(object? left, object? right)
+    private new static bool Equals(object? left, object? right)
     {
         if (left is null && right is null)
         {

--- a/src/Json/BitzArt.Json.TypedValues/Models/TypedValue.cs
+++ b/src/Json/BitzArt.Json.TypedValues/Models/TypedValue.cs
@@ -55,6 +55,60 @@ public abstract class TypedValue
         return Value?.ToString() ?? string.Empty;
     }
 
+    /// <summary>
+    /// Compares two <see cref="TypedValue"/> instances for equality.
+    /// </summary>
+    /// <param name="left">Left operand.</param>
+    /// <param name="right">Right operand.</param>
+    /// <returns><see langword="true"/> if instances are equal; otherwise, <see langword="false"/>.</returns>"
+    public static bool operator ==(TypedValue left, TypedValue right)
+        => left.Equals(right);
+
+    /// <summary>
+    /// Compares two <see cref="TypedValue"/> instances for inequality.
+    /// </summary>
+    /// <param name="left">Left operand.</param>
+    /// <param name="right">Right operand.</param>
+    /// <returns><see langword="true"/> if instances are not equal; otherwise, <see langword="false"/>.</returns>"
+    public static bool operator !=(TypedValue left, TypedValue right)
+        => !left.Equals(right);
+
+    /// <summary>
+    /// Compares two <see cref="TypedValue"/> instances for equality.
+    /// </summary>
+    /// <param name="left">Left operand.</param>
+    /// <param name="right">Right operand.</param>
+    /// <returns><see langword="true"/> if instances are equal; otherwise, <see langword="false"/>.</returns>"
+    public static bool operator ==(TypedValue left, object right)
+        => left.Equals(right);
+
+    /// <summary>
+    /// Compares two <see cref="TypedValue"/> instances for inequality.
+    /// </summary>
+    /// <param name="left">Left operand.</param>
+    /// <param name="right">Right operand.</param>
+    /// <returns><see langword="true"/> if instances are not equal; otherwise, <see langword="false"/>.</returns>"
+    public static bool operator !=(TypedValue left, object right)
+        => !left.Equals(right);
+
+    /// <summary>
+    /// Compares two <see cref="TypedValue"/> instances for equality.
+    /// </summary>
+    /// <param name="left">Left operand.</param>
+    /// <param name="right">Right operand.</param>
+    /// <returns><see langword="true"/> if instances are equal; otherwise, <see langword="false"/>.</returns>"
+    public static bool operator ==(object left, TypedValue right)
+        => left.Equals(right);
+
+    /// <summary>
+    /// Compares two <see cref="TypedValue"/> instances for inequality.
+    /// </summary>
+    /// <param name="left">Left operand.</param>
+    /// <param name="right">Right operand.</param>
+    /// <returns><see langword="true"/> if instances are not equal; otherwise, <see langword="false"/>.</returns>"
+    public static bool operator !=(object left, TypedValue right)
+        => !left.Equals(right);
+
     /// <inheritdoc/>
     public override bool Equals(object? obj)
     {

--- a/tests/Json/BitzArt.Json.TypedValues.Tests/Tests/ComparisonOperatorTests.cs
+++ b/tests/Json/BitzArt.Json.TypedValues.Tests/Tests/ComparisonOperatorTests.cs
@@ -1,0 +1,127 @@
+﻿using System.Text.Json;
+
+namespace BitzArt.Json.TypedValues.Tests;
+
+public class ComparisonOperatorTests
+{
+    [Fact]
+    public void EqualityOperator_BothTypedNull_ShouldReturnTrue()
+    {
+        TypedValue? value1 = null;
+        TypedValue? value2 = null;
+
+        bool result = value1 == value2;
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void EqualityOperator_LeftTypedBothNull_ShouldReturnTrue()
+    {
+        TypedValue? value1 = null;
+        object? value2 = null;
+
+        bool result = value1 == value2;
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void EqualityOperator_RightTypedBothNull_ShouldReturnTrue()
+    {
+        object? value1 = null;
+        TypedValue? value2 = null;
+
+        bool result = value1 == value2;
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void EqualityOperator_LeftNull_ShouldReturnFalse()
+    {
+        TypedValue? value1 = null;
+        TypedValue? value2 = "test";
+
+        bool result = value1 == value2;
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void EqualityOperator_RightNull_ShouldReturnFalse()
+    {
+        TypedValue? value1 = "test";
+        TypedValue? value2 = null;
+
+        bool result = value1 == value2;
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void EqualityOperator_BothTypedSameValue_ShouldReturnTrue()
+    {
+        TypedValue value1 = "test";
+        TypedValue value2 = "test";
+
+        bool result = value1 == value2;
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void EqualityOperator_BothTypedDifferentValue_ShouldReturnFalse()
+    {
+        TypedValue value1 = "test";
+        TypedValue value2 = "other";
+
+        bool result = value1 == value2;
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void EqualityOperator_LeftTypedSameValue_ShouldReturnTrue()
+    {
+        TypedValue value1 = "test";
+        string value2 = "test";
+
+        bool result = value1 == value2;
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void EqualityOperator_LeftTypedDifferentValue_ShouldReturnFalse()
+    {
+        TypedValue value1 = "test";
+        string value2 = "other";
+
+        bool result = value1 == value2;
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void EqualityOperator_RightTypedSameValue_ShouldReturnTrue()
+    {
+        string value1 = "test";
+        TypedValue value2 = "test";
+
+        bool result = value1 == value2;
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void EqualityOperator_RightTypedDifferentValue_ShouldReturnFalse()
+    {
+        string value1 = "test";
+        TypedValue value2 = "other";
+
+        bool result = value1 == value2;
+
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
This pull request adds operator overloads to the `TypedValue` class in `src/Json/BitzArt.Json.TypedValues/Models/TypedValue.cs` to improve equality and inequality comparisons. These changes enhance the usability and readability of the class when comparing instances.

### Added operator overloads for equality and inequality:

* Implemented `==` and `!=` operators for comparing two `TypedValue` instances. These operators check for their values' equality and inequality, respectively.
* Added `==` and `!=` operators for comparing a `TypedValue` instance with an `object`. These ensure proper comparisons when one operand is not explicitly typed as `TypedValue`, or is not a `TypedValue` at all.