### PR TITLE
Fallback to global service provider functionality

### DIFF
--- a/src/DependencyInjection/BitzArt.DependencyInjection.TransientServiceProvider/Extensions/ServiceCollectionExtensions.cs
+++ b/src/DependencyInjection/BitzArt.DependencyInjection.TransientServiceProvider/Extensions/ServiceCollectionExtensions.cs
@@ -12,10 +12,12 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddTransientServiceProvider(
         this IServiceCollection services,
         Action<IServiceCollection> configureServices,
-        Action<ITransientServiceProvider>? configureProvider = null)
+        Action<ITransientServiceProvider>? configureProvider = null,
+        Action<TransientServiceProviderOptions>? configureOptions = null)
         => services.AddTransientServiceProvider(
             (serviceCollection, _) => configureServices(serviceCollection),
-            configureProvider);
+            configureProvider,
+            configureOptions);
 
     /// <summary>
     /// Registers <see cref="ITransientServiceProviderFactory"/> and <see cref="ITransientServiceProvider"/> in the service collection.
@@ -23,7 +25,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddTransientServiceProvider(
         this IServiceCollection services,
         Action<IServiceCollection, IServiceProvider> configureServices,
-        Action<ITransientServiceProvider>? configureProvider = null)
+        Action<ITransientServiceProvider>? configureProvider = null,
+        Action<TransientServiceProviderOptions>? configureOptions = null)
     {
         if (services.Any(x => x.ServiceType == typeof(ITransientServiceProviderFactory)))
         {
@@ -31,7 +34,7 @@ public static class ServiceCollectionExtensions
         }
 
         services.AddSingleton<ITransientServiceProviderFactory>(globalServiceProvider =>
-            new TransientServiceProviderFactory(globalServiceProvider, configureServices, configureProvider));
+            new TransientServiceProviderFactory(globalServiceProvider, configureServices, configureProvider, configureOptions));
 
         services.AddTransient<ITransientServiceProvider>(x =>
         {

--- a/src/DependencyInjection/BitzArt.DependencyInjection.TransientServiceProvider/TransientServiceProvider.cs
+++ b/src/DependencyInjection/BitzArt.DependencyInjection.TransientServiceProvider/TransientServiceProvider.cs
@@ -69,12 +69,3 @@ internal class TransientServiceProvider : ITransientServiceProvider
         return service;
     }
 }
-
-
-public class TransientServiceProviderOptions 
-{
-    /// <summary>
-    /// Use global service provider if service missing in transient service provider
-    /// </summary>
-    public bool FallbackToGlobal { get; set; } = false;
-}

--- a/src/DependencyInjection/BitzArt.DependencyInjection.TransientServiceProvider/TransientServiceProvider.cs
+++ b/src/DependencyInjection/BitzArt.DependencyInjection.TransientServiceProvider/TransientServiceProvider.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using System.Collections;
+using System.Reflection;
 
 namespace BitzArt.DependencyInjection;
 
@@ -6,13 +8,73 @@ namespace BitzArt.DependencyInjection;
 /// The default implementation of <see cref="ITransientServiceProvider"/>.
 /// Delegates service resolution to inner <see cref="IServiceProvider"/>.
 /// </summary>
-internal class TransientServiceProvider(IServiceProvider innerServiceProvider) : ITransientServiceProvider
+internal class TransientServiceProvider : ITransientServiceProvider
 {
-    private readonly IServiceProvider _innerServiceProvider = innerServiceProvider;
+    private readonly IServiceProvider _globalServiceProvider;
+    private readonly TransientServiceProviderOptions _options;
+    private readonly IServiceProvider _innerServiceProvider;
+    
+    public TransientServiceProvider(IServiceProvider globalServiceProvider, 
+        Action<IServiceCollection, IServiceProvider> configureServices, 
+        Action<ITransientServiceProvider>? configure,
+        TransientServiceProviderOptions options)
+    {
+        _globalServiceProvider = globalServiceProvider;
+        _options = options;
+        var sc = new ServiceCollection();
+        configureServices(sc, globalServiceProvider);
+
+        _innerServiceProvider = sc.BuildServiceProvider();
+        configure?.Invoke(this);
+    }
 
     /// <inheritdoc/>
     object? IServiceProvider.GetService(Type serviceType)
     {
-        return _innerServiceProvider.GetService(serviceType);
+        if (IsTypeEnumerable(serviceType) 
+            || serviceType.GetInterfaces().Any(type => IsTypeEnumerable(type))) 
+        {
+            return GetEnumerable(serviceType);
+        }
+       
+        var service = _innerServiceProvider.GetService(serviceType); 
+
+        if (service is null && _options.FallbackToGlobal) {
+            return _globalServiceProvider.GetService(serviceType);
+        }
+
+        return service;
     }
+
+    private bool IsTypeEnumerable(Type serviceType)
+    {        
+        if (serviceType.IsGenericType && serviceType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private object? GetEnumerable(Type serviceType) 
+    {
+        var service = _innerServiceProvider.GetService(serviceType);
+
+        if ((service as IEnumerable)!.GetEnumerator().MoveNext() is false
+            && _options.FallbackToGlobal)
+        {
+            return _globalServiceProvider.GetService(serviceType);
+        }
+
+        return service;
+    }
+}
+
+
+public class TransientServiceProviderOptions 
+{
+    /// <summary>
+    /// Use global service provider if service missing in transient service provider
+    /// </summary>
+    public bool FallbackToGlobal { get; set; } = false;
 }

--- a/src/DependencyInjection/BitzArt.DependencyInjection.TransientServiceProvider/TransientServiceProviderOptions.cs
+++ b/src/DependencyInjection/BitzArt.DependencyInjection.TransientServiceProvider/TransientServiceProviderOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace BitzArt.DependencyInjection;
+
+/// <summary>
+/// Transient service provider options.
+/// </summary>
+public class TransientServiceProviderOptions 
+{
+    /// <summary>
+    /// Use global service provider if service missing in transient service provider.
+    /// </summary>
+    public bool FallbackToGlobal { get; set; } = false;
+}

--- a/tests/DependencyInjection/BitzArt.DependencyInjection.TransientServiceProvider.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/DependencyInjection/BitzArt.DependencyInjection.TransientServiceProvider.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,81 +1,80 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
-namespace BitzArt.DependencyInjection.TransientServiceProvider.Tests
+namespace BitzArt.DependencyInjection.TransientServiceProvider.Tests;
+
+public class ServiceCollectionExtensionsTests
 {
-    public class ServiceCollectionExtensionsTests
+    private class MyDependency(int value)
     {
-        private class MyDependency(int value)
-        {
-            public int Value { get; set; } = value;
-        }
+        public int Value { get; set; } = value;
+    }
 
-        [Fact]
-        public void AddTransientServiceProvider_WithServices_ShouldConfigureServiceProvider()
-        {
-            // Arrange
-            var globalServiceCollection = new ServiceCollection();
-            const int value = 15;
+    [Fact]
+    public void AddTransientServiceProvider_WithServices_ShouldConfigureServiceProvider()
+    {
+        // Arrange
+        var globalServiceCollection = new ServiceCollection();
+        const int value = 15;
 
-            // Act
+        // Act
+        globalServiceCollection.AddTransientServiceProvider(services =>
+        {
+            services.AddSingleton(new MyDependency(value));
+        });
+
+        // Assert
+        using var globalServiceProvider = globalServiceCollection.BuildServiceProvider();
+        var transientServiceProvider = globalServiceProvider.GetRequiredService<ITransientServiceProvider>();
+
+        var myDependency = transientServiceProvider.GetRequiredService<MyDependency>();
+        Assert.NotNull(myDependency);
+
+        Assert.Equal(value, myDependency.Value);
+    }
+
+    [Fact]
+    public void AddTransientServiceProvider_UsingGlobalServiceProvider_ShouldConfigureServiceProvider()
+    {
+        // Arrange
+        var globalServiceCollection = new ServiceCollection();
+        const int value = 15;
+
+        globalServiceCollection.AddSingleton(new MyDependency(value));
+
+        // Act
+        globalServiceCollection.AddTransientServiceProvider((services, global) =>
+        {
+            var myDependency = global.GetRequiredService<MyDependency>();
+            services.AddSingleton(myDependency);
+        });
+
+        // Assert
+        using var globalServiceProvider = globalServiceCollection.BuildServiceProvider();
+        var transientServiceProvider = globalServiceProvider.GetRequiredService<ITransientServiceProvider>();
+        var myDependency = transientServiceProvider.GetRequiredService<MyDependency>();
+        Assert.NotNull(myDependency);
+
+        Assert.Equal(value, myDependency.Value);
+    }
+
+    [Fact]
+    public void AddTransientServiceProvider_Twice_ShouldThrow()
+    {
+        // Arrange
+        var globalServiceCollection = new ServiceCollection();
+
+        // Act + Assert
+        globalServiceCollection.AddTransientServiceProvider(services =>
+        {
+            services.AddSingleton(new MyDependency(1));
+        });
+
+        Assert.ThrowsAny<Exception>(() =>
+        {
             globalServiceCollection.AddTransientServiceProvider(services =>
             {
-                services.AddSingleton(new MyDependency(value));
+                services.AddSingleton(new MyDependency(2));
             });
-
-            // Assert
-            using var globalServiceProvider = globalServiceCollection.BuildServiceProvider();
-            var transientServiceProvider = globalServiceProvider.GetRequiredService<ITransientServiceProvider>();
-
-            var myDependency = transientServiceProvider.GetRequiredService<MyDependency>();
-            Assert.NotNull(myDependency);
-
-            Assert.Equal(value, myDependency.Value);
-        }
-
-        [Fact]
-        public void AddTransientServiceProvider_UsingGlobalServiceProvider_ShouldConfigureServiceProvider()
-        {
-            // Arrange
-            var globalServiceCollection = new ServiceCollection();
-            const int value = 15;
-
-            globalServiceCollection.AddSingleton(new MyDependency(value));
-
-            // Act
-            globalServiceCollection.AddTransientServiceProvider((services, global) =>
-            {
-                var myDependency = global.GetRequiredService<MyDependency>();
-                services.AddSingleton(myDependency);
-            });
-
-            // Assert
-            using var globalServiceProvider = globalServiceCollection.BuildServiceProvider();
-            var transientServiceProvider = globalServiceProvider.GetRequiredService<ITransientServiceProvider>();
-            var myDependency = transientServiceProvider.GetRequiredService<MyDependency>();
-            Assert.NotNull(myDependency);
-
-            Assert.Equal(value, myDependency.Value);
-        }
-
-        [Fact]
-        public void AddTransientServiceProvider_Twice_ShouldThrow()
-        {
-            // Arrange
-            var globalServiceCollection = new ServiceCollection();
-
-            // Act + Assert
-            globalServiceCollection.AddTransientServiceProvider(services =>
-            {
-                services.AddSingleton(new MyDependency(1));
-            });
-
-            Assert.ThrowsAny<Exception>(() =>
-            {
-                globalServiceCollection.AddTransientServiceProvider(services =>
-                {
-                    services.AddSingleton(new MyDependency(2));
-                });
-            });
-        }
+        });
     }
 }

--- a/tests/DependencyInjection/BitzArt.DependencyInjection.TransientServiceProvider.Tests/TransientServiceProviderTests.cs
+++ b/tests/DependencyInjection/BitzArt.DependencyInjection.TransientServiceProvider.Tests/TransientServiceProviderTests.cs
@@ -96,7 +96,7 @@ public class TransientServiceProviderTests
     }
 
     [Fact]
-    public void GetEnumerableService_WithFallbackFalseAndTransientMissingService_ShouldReturnEmtpyEnumerable()
+    public void GetEnumerableService_WithFallbackFalseAndTransientMissingService_ShouldReturnEmptyEnumerable()
     {
         // Arrange
         var globalServiceCollection = new ServiceCollection();

--- a/tests/DependencyInjection/BitzArt.DependencyInjection.TransientServiceProvider.Tests/TransientServiceProviderTests.cs
+++ b/tests/DependencyInjection/BitzArt.DependencyInjection.TransientServiceProvider.Tests/TransientServiceProviderTests.cs
@@ -1,0 +1,126 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace BitzArt.DependencyInjection.TransientServiceProvider.Tests;
+
+public class TransientServiceProviderTests
+{
+    private class MyDependency(int value)
+    {
+        public int Value { get; set; } = value;
+    }
+
+    [Fact]
+    public void GetService_ViaFallback_ShouldReturnServiceFromGlobal()
+    {
+        // Arrange
+        var globalServiceCollection = new ServiceCollection();
+        const int value = 15;
+
+        globalServiceCollection.AddSingleton(new MyDependency(value));
+
+        // Act
+        globalServiceCollection.AddTransientServiceProvider(services =>
+        {
+
+        },
+        configureOptions: options => {
+            options.FallbackToGlobal = true;
+        });
+
+        // Assert
+        using var globalServiceProvider = globalServiceCollection.BuildServiceProvider();
+        var transientServiceProvider = globalServiceProvider.GetRequiredService<ITransientServiceProvider>();
+
+        var myDependency = transientServiceProvider.GetRequiredService<MyDependency>();
+
+        Assert.NotNull(myDependency);
+        Assert.Equal(value, myDependency.Value);
+
+    }
+
+    [Fact]
+    public void GetEnumerableService_ViaFallback_ShouldReturnEnumerableServiceFromGlobal()
+    {
+        // Arrange
+        var globalServiceCollection = new ServiceCollection();
+        const int value = 15;
+
+        globalServiceCollection.AddSingleton(new MyDependency(value));
+
+        // Act
+        globalServiceCollection.AddTransientServiceProvider(services =>
+        {
+
+        },
+        configureOptions: options => {
+            options.FallbackToGlobal = true;
+        });
+
+        // Assert
+        using var globalServiceProvider = globalServiceCollection.BuildServiceProvider();
+        var transientServiceProvider = globalServiceProvider.GetRequiredService<ITransientServiceProvider>();
+
+        var myDependency = transientServiceProvider.GetRequiredService<IEnumerable<MyDependency>>();
+
+        Assert.NotNull(myDependency);
+        Assert.Single(myDependency);
+        Assert.Equal(value, myDependency.Single().Value);
+
+    }
+
+    [Fact]
+    public void GetService_WithFallbackFalseAndTransientMissingService_ShouldReturnNull()
+    {
+        // Arrange
+        var globalServiceCollection = new ServiceCollection();
+        const int value = 15;
+
+        globalServiceCollection.AddSingleton(new MyDependency(value));
+
+        // Act
+        globalServiceCollection.AddTransientServiceProvider(services =>
+        {
+
+        },
+        configureOptions: options => {
+            options.FallbackToGlobal = false;
+        });
+
+        // Assert
+        using var globalServiceProvider = globalServiceCollection.BuildServiceProvider();
+        var transientServiceProvider = globalServiceProvider.GetRequiredService<ITransientServiceProvider>();
+
+        var myDependency = transientServiceProvider.GetService<MyDependency>();
+
+        Assert.Null(myDependency);
+    }
+
+    [Fact]
+    public void GetEnumerableService_WithFallbackFalseAndTransientMissingService_ShouldReturnEmtpyEnumerable()
+    {
+        // Arrange
+        var globalServiceCollection = new ServiceCollection();
+        const int value = 15;
+
+        globalServiceCollection.AddSingleton(new MyDependency(value));
+
+        // Act
+        globalServiceCollection.AddTransientServiceProvider(services =>
+        {
+
+        },
+        configureOptions: options => {
+            options.FallbackToGlobal = false;
+        });
+
+        // Assert
+        using var globalServiceProvider = globalServiceCollection.BuildServiceProvider();
+        var transientServiceProvider = globalServiceProvider.GetRequiredService<ITransientServiceProvider>();
+
+        var myDependency = transientServiceProvider.GetRequiredService<IEnumerable<MyDependency>>();
+
+        Assert.NotNull(myDependency);
+        Assert.Empty(myDependency);
+
+    }
+}


### PR DESCRIPTION
This pull request adds support for configurable fallback behavior in the transient service provider implementation. The main change is the introduction of the `TransientServiceProviderOptions` class, allowing consumers to specify whether the transient provider should fall back to the global provider when a requested service is missing. The PR also updates relevant extension methods, factory, and provider classes to support this option, and introduces comprehensive tests to verify the new behavior.

### Configurable fallback support

* Added the `TransientServiceProviderOptions` class with a `FallbackToGlobal` property to control fallback behavior when resolving services in `TransientServiceProvider`.
* Updated `ServiceCollectionExtensions.AddTransientServiceProvider` methods to accept an optional `configureOptions` parameter for configuring fallback behavior.
* Modified `TransientServiceProvider` to use the new options and implement fallback logic for both single and enumerable service requests.
* Refactored `TransientServiceProviderFactory` to accept and propagate `TransientServiceProviderOptions`, ensuring consistent fallback configuration across providers. [[1]](diffhunk://#diff-cbfe5f32d56c727a6e8b1917acec040b671805a4863d4f1d2c29dbe2f04d000aL6-R30) [[2]](diffhunk://#diff-cbfe5f32d56c727a6e8b1917acec040b671805a4863d4f1d2c29dbe2f04d000aL38-L49)

### Test coverage

* Added `TransientServiceProviderTests` to verify fallback behavior for single and enumerable service resolution, both when fallback is enabled and disabled.